### PR TITLE
✨ Terraform version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features:
 
 - Implement the `validate` and `fmt` method in the `TerraformService`.
 - Implement the `ProjectInit` and `ProjectLint` functions for Terraform.
+- Check the Terraform version before running commands, through the new `terraform.version` configuration.
 
 ## v0.1.0 (2023-05-18)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@causa/workspace": ">= 0.10.0 < 1.0.0",
         "@causa/workspace-core": ">= 0.7.0 < 1.0.0",
-        "pino": "^8.14.1"
+        "pino": "^8.14.1",
+        "semver": "^7.5.1"
       },
       "devDependencies": {
         "@tsconfig/node18": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "@causa/workspace": ">= 0.10.0 < 1.0.0",
     "@causa/workspace-core": ">= 0.7.0 < 1.0.0",
-    "pino": "^8.14.1"
+    "pino": "^8.14.1",
+    "semver": "^7.5.1"
   },
   "devDependencies": {
     "@tsconfig/node18": "^2.0.1",

--- a/src/configurations/terraform.ts
+++ b/src/configurations/terraform.ts
@@ -10,5 +10,13 @@ export type TerraformConfiguration = {
      * The Terraform workspace that should be selected prior to performing `plan` and `apply` operations.
      */
     workspace?: string;
+
+    /**
+     * The version of Terraform to use.
+     * Can be a semver version, or `latest`.
+     * The installed version is considered compatible if it is greater than or equal to the configured version, within
+     * the same major version.
+     */
+    version?: string;
   };
 };

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,1 +1,2 @@
+export * from './terraform.errors.js';
 export { TerraformService } from './terraform.js';

--- a/src/services/terraform.errors.ts
+++ b/src/services/terraform.errors.ts
@@ -1,0 +1,14 @@
+/**
+ * An error thrown when the installed Terraform version is incompatible with the required version set in the
+ * configuration.
+ */
+export class IncompatibleTerraformVersionError extends Error {
+  constructor(
+    readonly installedVersion: string,
+    readonly requiredVersion: string,
+  ) {
+    super(
+      `Installed Terraform version ${installedVersion} is incompatible with required version ${requiredVersion}.`,
+    );
+  }
+}


### PR DESCRIPTION
This PR implements a version check prior to running Terraform commands, based on the version configured in `terraform.version`. This is extremely similar to the npm version check of the TypeScript module.

### Commits

- ➕ Depend on semver
- ✨ Define the terraform.version configuration
- ✨ Check the Terraform version before running commands
- 📝 Update changelog