### PR TITLE
✨ Implement `ProjectDependenciesUpdate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Features:
 
 - Support the `--destroy` option for the `infrastructure prepare` command.
+- Support the `dependencies update` command (`ProjectDependenciesUpdate` function).
 
 ## v0.2.0 (2023-06-09)
 

--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ The Terraform module also supports some of the project-level commands, namely:
 
 - `cs init`: Runs `terraform init`.
 - `cs lint`: Runs `terraform validate` and `terraform fmt`. The format operation is run with the `-check` argument, such that it only lints the code without fixing it. This operation applies supports the `project.additionalDirectories` configuration.
+- `cs dependencies update`: Runs `terraform init` with the `-upgrade` option, allowing the update of dependencies and the lock file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.12.0 < 1.0.0",
-        "@causa/workspace-core": ">= 0.10.0 < 1.0.0",
+        "@causa/workspace-core": ">= 0.11.0 < 1.0.0",
         "pino": "^8.14.2",
         "semver": "^7.5.4"
       },
@@ -679,9 +679,9 @@
       }
     },
     "node_modules/@causa/workspace-core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@causa/workspace-core/-/workspace-core-0.10.0.tgz",
-      "integrity": "sha512-UnN29OuPton4s2Wj2kVydxUGL5g6Kjf7Vr+iZfJb0gtUk/BFNVfTuUB+JjD/aXaPjFDXxj9OT2YNEaqWXBsK7Q==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@causa/workspace-core/-/workspace-core-0.11.0.tgz",
+      "integrity": "sha512-VvmIfkIW+b0ZiEmWfF3IT/Mt1aRxv0sHcvcESfg3vQVmrNB8B+1ynfyE1nd16AVduVJMJCHIv3cb8ZIx59skiA==",
       "dependencies": {
         "@causa/cli": ">= 0.4.0 < 1.0.0",
         "@causa/workspace": ">= 0.12.0 < 1.0.0",
@@ -2300,9 +2300,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001517",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
-      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
+      "version": "1.0.30001518",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz",
+      "integrity": "sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@causa/workspace": ">= 0.12.0 < 1.0.0",
-    "@causa/workspace-core": ">= 0.10.0 < 1.0.0",
+    "@causa/workspace-core": ">= 0.11.0 < 1.0.0",
     "pino": "^8.14.2",
     "semver": "^7.5.4"
   },

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1,6 +1,7 @@
 import { ModuleRegistrationContext } from '@causa/workspace';
 import { InfrastructureDeployForTerraform } from './infrastructure-deploy-terraform.js';
 import { InfrastructurePrepareForTerraform } from './infrastructure-prepare-terraform.js';
+import { ProjectDependenciesUpdateForTerraform } from './project-dependencies-update-terraform.js';
 import { ProjectInitForTerraform } from './project-init-terraform.js';
 import { ProjectLintForTerraform } from './project-lint-terraform.js';
 
@@ -8,6 +9,7 @@ export function registerFunctions(context: ModuleRegistrationContext) {
   context.registerFunctionImplementations(
     InfrastructureDeployForTerraform,
     InfrastructurePrepareForTerraform,
+    ProjectDependenciesUpdateForTerraform,
     ProjectInitForTerraform,
     ProjectLintForTerraform,
   );

--- a/src/functions/project-dependencies-update-terraform.spec.ts
+++ b/src/functions/project-dependencies-update-terraform.spec.ts
@@ -1,0 +1,48 @@
+import { WorkspaceContext } from '@causa/workspace';
+import { ProjectDependenciesUpdate } from '@causa/workspace-core';
+import { NoImplementationFoundError } from '@causa/workspace/function-registry';
+import { createContext } from '@causa/workspace/testing';
+import { jest } from '@jest/globals';
+import 'jest-extended';
+import { TerraformService } from '../services/index.js';
+import { ProjectDependenciesUpdateForTerraform } from './project-dependencies-update-terraform.js';
+
+describe('ProjectDependenciesUpdateForTerraform', () => {
+  let context: WorkspaceContext;
+  let terraformService: TerraformService;
+
+  beforeEach(async () => {
+    ({ context } = createContext({
+      configuration: {
+        workspace: { name: '🏷️' },
+        project: { name: '🏗️', type: 'infrastructure', language: 'terraform' },
+      },
+      functions: [ProjectDependenciesUpdateForTerraform],
+    }));
+    terraformService = context.service(TerraformService);
+    jest.spyOn(terraformService, 'init').mockResolvedValue();
+  });
+
+  it('should not handle non-terraform projects', async () => {
+    ({ context } = createContext({
+      configuration: {
+        workspace: { name: '🏷️' },
+        project: { name: '🏗️', type: 'infrastructure', language: 'python' },
+      },
+      functions: [ProjectDependenciesUpdateForTerraform],
+    }));
+
+    expect(() => context.call(ProjectDependenciesUpdate, {})).toThrow(
+      NoImplementationFoundError,
+    );
+  });
+
+  it('should run terraform init with the upgrade option', async () => {
+    await context.call(ProjectDependenciesUpdate, {});
+
+    expect(terraformService.init).toHaveBeenCalledExactlyOnceWith({
+      upgrade: true,
+      logging: 'debug',
+    });
+  });
+});

--- a/src/functions/project-dependencies-update-terraform.ts
+++ b/src/functions/project-dependencies-update-terraform.ts
@@ -1,0 +1,27 @@
+import { WorkspaceContext } from '@causa/workspace';
+import { ProjectDependenciesUpdate } from '@causa/workspace-core';
+import { TerraformService } from '../services/index.js';
+
+/**
+ * Implements the {@link ProjectDependenciesUpdate} function for Terraform projects, by running `terraform init`.
+ * This uses the `-upgrade` option to fetch the latest versions of the providers allowed by configured constraints, and
+ * updates the lock file accordingly.
+ */
+export class ProjectDependenciesUpdateForTerraform extends ProjectDependenciesUpdate {
+  async _call(context: WorkspaceContext): Promise<void> {
+    context.logger.info('⬆️ Updating Terraform dependencies.');
+
+    await context
+      .service(TerraformService)
+      .init({ upgrade: true, logging: 'debug' });
+
+    context.logger.info(`️✅ Successfully updated Terraform dependencies.`);
+  }
+
+  _supports(context: WorkspaceContext): boolean {
+    return (
+      context.get('project.language') === 'terraform' &&
+      context.get('project.type') === 'infrastructure'
+    );
+  }
+}

--- a/src/services/terraform.spec.ts
+++ b/src/services/terraform.spec.ts
@@ -87,6 +87,19 @@ describe('TerraformService', () => {
       expect(actualCommand).toEqual('init');
       expect(actualArgs).toContain('-input=false');
     });
+
+    it('should set the upgrade option', async () => {
+      terraformSpy.mockResolvedValueOnce({ code: 0 });
+
+      await service.init({ upgrade: true });
+
+      expect(service.terraform).toHaveBeenCalledOnce();
+      const [actualCommand, args] = terraformSpy.mock.calls[0];
+      const actualArgs = args.join(' ');
+      expect(actualCommand).toEqual('init');
+      expect(actualArgs).toContain('-upgrade');
+      expect(actualArgs).toContain('-input=false');
+    });
   });
 
   describe('workspaceShow', () => {

--- a/src/services/terraform.ts
+++ b/src/services/terraform.ts
@@ -78,8 +78,21 @@ export class TerraformService {
    *
    * @param options Options when initializing Terraform.
    */
-  async init(options: SpawnOptions = {}): Promise<void> {
-    await this.terraform('init', ['-input=false'], options);
+  async init(
+    options: {
+      /**
+       * Upgrades the module and provider versions during initialization, instead of using the lockfile.
+       */
+      upgrade?: boolean;
+    } & SpawnOptions = {},
+  ): Promise<void> {
+    const args: string[] = ['-input=false'];
+
+    if (options.upgrade) {
+      args.push('-upgrade');
+    }
+
+    await this.terraform('init', args, options);
   }
 
   /**
@@ -105,7 +118,12 @@ export class TerraformService {
    */
   async workspaceSelect(
     workspace: string,
-    options: { orCreate?: boolean } & SpawnOptions = {},
+    options: {
+      /**
+       * Creates the workspace if it does not already exists.
+       */
+      orCreate?: boolean;
+    } & SpawnOptions = {},
   ): Promise<void> {
     const { orCreate, ...spawnOptions } = options;
     await this.terraform(


### PR DESCRIPTION
This PR implements support for the `cs dependencies update` command for Terraform projects.

### Commits

- ⬆️ Upgrade dependencies
- ✨ Implement the upgrade option for TerraformService.init
- ✨ Implement ProjectDependenciesUpdate for Terraform projects
- 📝 Document support for cs dependencies update
- 📝 Update changelog