### PR TITLE
🔖 Prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.4.0 (2023-10-06)
+
 Breaking changes:
 
 - When the plan file location is not specified in `cs infrastructure prepare`, it now defaults to a `plan.out` file in the project's directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-terraform",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-terraform",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.12.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-terraform",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "The Causa workspace module providing functionalities for infrastructure projects coded in Terraform.",
   "repository": "github:causa-io/workspace-module-terraform",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- When the plan file location is not specified in `cs infrastructure prepare`, it now defaults to a `plan.out` file in the project's directory.
- When the prepared plan contains no change, the plan file is removed from the output location.
- The plan file is removed after a successful `cs infrastructure deploy`.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.4.0