### PR TITLE
🔖 Prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.5.0 (2024-05-21)
+
 Breaking change:
 
 - Drop support for Node.js 16.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-terraform",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-terraform",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.13.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-terraform",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "The Causa workspace module providing functionalities for infrastructure projects coded in Terraform.",
   "repository": "github:causa-io/workspace-module-terraform",
   "license": "ISC",


### PR DESCRIPTION
Breaking change:

- Drop support for Node.js 16.

Chore:

- Upgrade dependencies.

### Commits

- **🔖 Set version to 0.5.0**
- **📝 Update changelog**