### PR TITLE
💥 Linting improvements and breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Breaking change:
+
+- Use the new `project.externalFiles` configuration when linting Terraform files, instead of `project.additionalDirectories`.
+- Do not run `terraform validate` during `cs lint` because it may require additional Terraform configuration.
+
 ## v0.5.0 (2024-05-21)
 
 Breaking change:

--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ The `terraform.workspace` configuration determines the Terraform workspace set p
 The Terraform module also supports some of the project-level commands, namely:
 
 - `cs init`: Runs `terraform init`.
-- `cs lint`: Runs `terraform validate` and `terraform fmt`. The format operation is run with the `-check` argument, such that it only lints the code without fixing it. This operation applies supports the `project.additionalDirectories` configuration.
+- `cs lint`: Runs `terraform fmt`. The format operation is run with the `-check` argument, such that it only lints the code without fixing it. This operation supports the `project.externalFiles` configuration, by linting all Terraform files matching the glob patterns.
 - `cs dependencies update`: Runs `terraform init` with the `-upgrade` option, allowing the update of dependencies and the lock file.

--- a/src/functions/project-lint-terraform.spec.ts
+++ b/src/functions/project-lint-terraform.spec.ts
@@ -16,7 +16,7 @@ describe('ProjectLintForTerraform', () => {
   let tmpDir: string;
   let context: WorkspaceContext;
   let terraformService: TerraformService;
-  let validateMock: jest.SpiedFunction<TerraformService['validate']>;
+  let fmtSpy: jest.SpiedFunction<TerraformService['fmt']>;
 
   beforeEach(async () => {
     tmpDir = resolve(await mkdtemp('causa-test-'));
@@ -38,8 +38,7 @@ describe('ProjectLintForTerraform', () => {
       ...options,
     }));
     terraformService = context.service(TerraformService);
-    jest.spyOn(terraformService, 'fmt').mockResolvedValue({ code: 0 });
-    validateMock = jest.spyOn(terraformService, 'validate').mockResolvedValue();
+    fmtSpy = jest.spyOn(terraformService, 'fmt').mockResolvedValue({ code: 0 });
   }
 
   it('should not handle non-terraform projects', async () => {
@@ -55,12 +54,9 @@ describe('ProjectLintForTerraform', () => {
     );
   });
 
-  it('should run terraform validate and fmt', async () => {
+  it('should run terraform fmt', async () => {
     await context.call(ProjectLint, {});
 
-    expect(terraformService.validate).toHaveBeenCalledExactlyOnceWith({
-      logging: { stdout: null, stderr: 'info' },
-    });
     expect(terraformService.fmt).toHaveBeenCalledExactlyOnceWith({
       check: true,
       recursive: true,
@@ -96,9 +92,6 @@ describe('ProjectLintForTerraform', () => {
 
     await context.call(ProjectLint, {});
 
-    expect(terraformService.validate).toHaveBeenCalledExactlyOnceWith({
-      logging: { stdout: null, stderr: 'info' },
-    });
     expect(terraformService.fmt).toHaveBeenCalledExactlyOnceWith({
       check: true,
       recursive: true,
@@ -108,7 +101,7 @@ describe('ProjectLintForTerraform', () => {
   });
 
   it('should throw when one of the terraform commands fails', async () => {
-    validateMock.mockRejectedValueOnce(
+    fmtSpy.mockRejectedValueOnce(
       new ProcessServiceExitCodeError('terraform', [], { code: 1 }),
     );
 

--- a/src/functions/project-lint-terraform.ts
+++ b/src/functions/project-lint-terraform.ts
@@ -11,8 +11,7 @@ import { TerraformService } from '../services/index.js';
 const TERRAFORM_FILE_EXTENSIONS = ['.tf', '.tfvars', '.tftest.hcl'];
 
 /**
- * Implements the {@link ProjectLint} function for Terraform projects, by running `terraform validate` and
- * `terraform fmt`.
+ * Implements the {@link ProjectLint} function for Terraform projects, by running `terraform fmt`.
  * The Terraform format check is also run on any external files listed in the project configuration.
  */
 export class ProjectLintForTerraform extends ProjectLint {
@@ -27,13 +26,6 @@ export class ProjectLintForTerraform extends ProjectLint {
     const targets = [projectPath, ...externalTerraformFiles];
 
     try {
-      context.logger.info(
-        `🚨 Validating Terraform code for project '${projectName}'.`,
-      );
-      await terraformService.validate({
-        logging: { stdout: null, stderr: 'info' },
-      });
-
       context.logger.info(
         `🎨 Checking format of Terraform code for project '${projectName}'.`,
       );


### PR DESCRIPTION
This PR:

- Adapts to breaking changes in the configuration (`project.additionalDirectories` being replaced by `project.externalFiles`).
- No longer runs `terraform validate` when linting. The `validate` command requires a fully configured Terraform configuration, however this is not guaranteed during a `cs lint` step. For example, the Terraform configuration could depend on a (Causa) environment to be selected, or preprocessing steps.

### Commits

- **💥 List all Terraform files in project.externalFiles when linting**
- **💥 Remove terraform validate call in ProjectLint function**
- **📝 Update changelog**
- **📝 Update documentation for cs lint**