### PR TITLE
🔖 Prepare v0.11.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.11.0-beta.1 (2026-05-18)
+
 Chores:
 
 - Adapt to `@causa/workspace` breaking changes: `_call` and `_supports` no longer take a `context` argument and instead use the `_context` property.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-terraform",
-  "version": "0.10.0",
+  "version": "0.11.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-terraform",
-      "version": "0.10.0",
+      "version": "0.11.0-beta.1",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.25.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-terraform",
-  "version": "0.10.0",
+  "version": "0.11.0-beta.1",
   "description": "The Causa workspace module providing functionalities for infrastructure projects coded in Terraform.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Chores:

- Adapt to `@causa/workspace` breaking changes: `_call` and `_supports` no longer take a `context` argument and instead use the `_context` property.
- Replace `js-yaml` with `yaml` in the schema transformation script.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~