### PR TITLE
⬆️ Upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@causa/workspace": ">=1.0.0",
         "@causa/workspace-core": ">=1.0.1",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.15.1",
         "globby": "^16.2.0",
         "pino": "^10.3.1",
         "semver": "^7.8.3"
@@ -20,7 +22,7 @@
         "@swc/jest": "^0.2.39",
         "@tsconfig/node22": "^22.0.5",
         "@types/jest": "^30.0.0",
-        "@types/node": "^20.19.42",
+        "@types/node": "^22.19.21",
         "@types/semver": "^7.7.1",
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
@@ -1979,9 +1981,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
-      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   "dependencies": {
     "@causa/workspace": ">=1.0.0",
     "@causa/workspace-core": ">=1.0.1",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.15.1",
     "globby": "^16.2.0",
     "pino": "^10.3.1",
     "semver": "^7.8.3"
@@ -45,7 +47,7 @@
     "@swc/jest": "^0.2.39",
     "@tsconfig/node22": "^22.0.5",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20.19.42",
+    "@types/node": "^22.19.21",
     "@types/semver": "^7.7.1",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
### 📝 Description of the PR

Bumps the Node.js type definitions (`@types/node`) to v22 to match the Node 22 runtime, and declares `class-transformer` and `class-validator` as explicit dependencies as they are used by the generated configuration code.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.
